### PR TITLE
Allows users to specify the number of snapshots to preserve, where 0

### DIFF
--- a/org.lamport.tla.toolbox.doc/html/model/executing-tlc.html
+++ b/org.lamport.tla.toolbox.doc/html/model/executing-tlc.html
@@ -224,13 +224,14 @@ The model is automatically saved when you run or validate it, so you will
 probably have no reason to save it explicitly.
 </p>
 
-<h3>Take snapshot of model after completion of model checking</h3>
+<h3>Number of model snapshots to keep</h3>
 <p>
 Re-running a model erases the corresponding model checking results if any. With snapshots
-activate, the Toolbox creates a history of model runs. The history allows one to trace back
-the evolution of the specification and corresponding model.
+activate, the Toolbox maintains a history of the N most recent model runs. The value N is defined 
+by <samp>Number of model snapshots to keep</samp> where zero disables snapshots completely.
+The history allows one to trace back the evolution of the specification and corresponding model.
 </p>
-<p>Snapshots can be deleted in the Spec Explorer as needed.
+<p>Snapshots can also be deleted in the Spec Explorer as needed.
 </p>
 
 <h3>Maximum JVM Heap Size</h3>

--- a/org.lamport.tla.toolbox.tool.tlc.ui/src/org/lamport/tla/toolbox/tool/tlc/ui/preference/TLCPreferenceInitializer.java
+++ b/org.lamport.tla.toolbox.tool.tlc.ui/src/org/lamport/tla/toolbox/tool/tlc/ui/preference/TLCPreferenceInitializer.java
@@ -28,24 +28,30 @@ public class TLCPreferenceInitializer extends AbstractPreferenceInitializer
      */
     public void initializeDefaultPreferences()
     {
+        final IPreferenceStore uiPreferencesStore = TLCUIActivator.getDefault().getPreferenceStore();
+        final IPreferenceStore tlcPreferencesStore = TLCActivator.getDefault().getPreferenceStore();
 
-        final IPreferenceStore store = TLCUIActivator.getDefault().getPreferenceStore();
-        store.setDefault(ITLCPreferenceConstants.I_TLC_TRACE_MAX_SHOW_ERRORS, 10000);
-        store.setDefault(ITLCPreferenceConstants.I_TLC_POPUP_ERRORS, true);
-        store.setDefault(ITLCPreferenceConstants.I_TLC_REVALIDATE_ON_MODIFY, true);
-        store.setDefault(TLCActivator.I_TLC_SNAPSHOT_PREFERENCE, true);
-        store.setDefault(ITLCPreferenceConstants.I_TLC_MAXIMUM_HEAP_SIZE_DEFAULT, MAX_HEAP_SIZE_DEFAULT);
-        store.setDefault(ITLCPreferenceConstants.I_TLC_MAXSETSIZE_DEFAULT, TLCGlobals.setBound);
-        store.setDefault(ITLCPreferenceConstants.I_TLC_FPBITS_DEFAULT, 1);
-        store.setDefault(ITLCPreferenceConstants.I_TLC_FPSETIMPL_DEFAULT, FPSetFactory.getImplementationDefault());
-        store.setDefault(ITLCPreferenceConstants.I_TLC_AUTO_LOCK_MODEL_TIME,
+        tlcPreferencesStore.setDefault(TLCActivator.I_TLC_SNAPSHOT_KEEP_COUNT, 10);
+
+        // This is so bad.. we store them in parallel because one is needed by plugin relied upon the PreferencePage
+        //      and the other by a plugin which is on the opposite side of the dependency. (TLCModelLaunchDelegate)
+        uiPreferencesStore.setDefault(TLCActivator.I_TLC_SNAPSHOT_KEEP_COUNT, 10);
+
+        uiPreferencesStore.setDefault(ITLCPreferenceConstants.I_TLC_TRACE_MAX_SHOW_ERRORS, 10000);
+        uiPreferencesStore.setDefault(ITLCPreferenceConstants.I_TLC_POPUP_ERRORS, true);
+        uiPreferencesStore.setDefault(ITLCPreferenceConstants.I_TLC_REVALIDATE_ON_MODIFY, true);
+        uiPreferencesStore.setDefault(ITLCPreferenceConstants.I_TLC_MAXIMUM_HEAP_SIZE_DEFAULT, MAX_HEAP_SIZE_DEFAULT);
+        uiPreferencesStore.setDefault(ITLCPreferenceConstants.I_TLC_MAXSETSIZE_DEFAULT, TLCGlobals.setBound);
+        uiPreferencesStore.setDefault(ITLCPreferenceConstants.I_TLC_FPBITS_DEFAULT, 1);
+        uiPreferencesStore.setDefault(ITLCPreferenceConstants.I_TLC_FPSETIMPL_DEFAULT, FPSetFactory.getImplementationDefault());
+        uiPreferencesStore.setDefault(ITLCPreferenceConstants.I_TLC_AUTO_LOCK_MODEL_TIME,
                 IModelConfigurationDefaults.MODEL_AUTO_LOCK_TIME_DEFAULT);
         // store.setDefault(ITLCPreferenceConstants.I_TLC_DELETE_PREVIOUS_FILES, true);
 
 		// By default we want the Toolbox to show a modal progress dialog upon TLC
 		// startup. A user can opt to subsequently suppress the dialog.
 		// This restores the behavior prior to https://bugs.eclipse.org/146205#c10.
-        if (!store.contains(ITLCPreferenceConstants.I_TLC_SHOW_MODAL_PROGRESS)) {
+        if (!uiPreferencesStore.contains(ITLCPreferenceConstants.I_TLC_SHOW_MODAL_PROGRESS)) {
 			final IEclipsePreferences node = InstanceScope.INSTANCE
 					.getNode(WorkbenchPlugin.getDefault().getBundle().getSymbolicName());
 			node.putBoolean(IPreferenceConstants.RUN_IN_BACKGROUND, false);
@@ -55,7 +61,7 @@ public class TLCPreferenceInitializer extends AbstractPreferenceInitializer
 				TLCUIActivator.getDefault().logError("Error trying to flush the workbench plugin preferences store.",
 						e);
 			}
-			store.setValue(ITLCPreferenceConstants.I_TLC_SHOW_MODAL_PROGRESS, true);
+			uiPreferencesStore.setValue(ITLCPreferenceConstants.I_TLC_SHOW_MODAL_PROGRESS, true);
 		}
     }
 }

--- a/org.lamport.tla.toolbox.tool.tlc.ui/src/org/lamport/tla/toolbox/tool/tlc/ui/preference/TLCPreferencePage.java
+++ b/org.lamport.tla.toolbox.tool.tlc.ui/src/org/lamport/tla/toolbox/tool/tlc/ui/preference/TLCPreferencePage.java
@@ -33,8 +33,8 @@ public class TLCPreferencePage extends FieldEditorPreferencePage implements IWor
 			@Override
 			public void propertyChange(PropertyChangeEvent event) {
 				final IPreferenceStore store = TLCActivator.getDefault().getPreferenceStore();
-				if (TLCActivator.I_TLC_SNAPSHOT_PREFERENCE.equals(event.getProperty())) {
-					store.setValue(TLCActivator.I_TLC_SNAPSHOT_PREFERENCE, (boolean) event.getNewValue());
+				if (TLCActivator.I_TLC_SNAPSHOT_KEEP_COUNT.equals(event.getProperty())) {
+					store.setValue(TLCActivator.I_TLC_SNAPSHOT_KEEP_COUNT, (int)event.getNewValue());
 				}
 			}
 		});
@@ -59,15 +59,21 @@ public class TLCPreferencePage extends FieldEditorPreferencePage implements IWor
 
         addField(new BooleanFieldEditor(ITLCPreferenceConstants.I_TLC_REVALIDATE_ON_MODIFY,
                 "&Re-validate model on save", getFieldEditorParent()));
-		addField(new BooleanFieldEditor(TLCActivator.I_TLC_SNAPSHOT_PREFERENCE,
-                "Take &snapshot of model after completion of model checking", getFieldEditorParent()));
+
+        IntegerFieldEditor integerFieldEditor = new IntegerFieldEditor(TLCActivator.I_TLC_SNAPSHOT_KEEP_COUNT,
+                                                                       "Number of model &snapshots to keep",
+                                                                       getFieldEditorParent());
+        integerFieldEditor.setValidRange(0, Integer.MAX_VALUE);
+        addField(integerFieldEditor);
+        
         // addField(new BooleanFieldEditor(ITLCPreferenceConstants.I_TLC_DELETE_PREVIOUS_FILES,
         // "&Automatically delete unused data from previous model run", getFieldEditorParent()));
         addField(new IntegerFieldEditor(ITLCPreferenceConstants.I_TLC_MAXIMUM_HEAP_SIZE_DEFAULT,
                 "Maximum JVM Heap Size default in % of physical system memory", getFieldEditorParent()));
         addField(new IntegerFieldEditor(ITLCPreferenceConstants.I_TLC_AUTO_LOCK_MODEL_TIME, "TLC run auto-lock time (in minutes)",
                 getFieldEditorParent()));
-		IntegerFieldEditor integerFieldEditor = new IntegerFieldEditor(ITLCPreferenceConstants.I_TLC_TRACE_MAX_SHOW_ERRORS,
+		
+        integerFieldEditor = new IntegerFieldEditor(ITLCPreferenceConstants.I_TLC_TRACE_MAX_SHOW_ERRORS,
 				"Default number of states shown in error traces", getFieldEditorParent());
 		integerFieldEditor.setValidRange(1, Integer.MAX_VALUE);
 		addField(integerFieldEditor);

--- a/org.lamport.tla.toolbox.tool.tlc/src/org/lamport/tla/toolbox/tool/tlc/TLCActivator.java
+++ b/org.lamport.tla.toolbox.tool.tlc/src/org/lamport/tla/toolbox/tool/tlc/TLCActivator.java
@@ -9,10 +9,16 @@ import org.osgi.framework.BundleContext;
  */
 public class TLCActivator extends AbstractUIPlugin {
 	
+    // TODO This is the only constant used in our Preferences that is not declared in ITLCPreferenceConstants
+    //          because of package dependency issues. We should do something about that because this scattering
+    //          feels meh.
 	/**
-	 * Take a model snapshot when model checking finishes to create a history of model runs. 
+     * This preference is exposed through the Toolbox preference pane and allows the
+     * user to dictate how many snapshots are kept (with the oldest being pruned as
+     * this value is reached or exceeded.)  A value of 0 here means that no snapshot
+     * is taken as part of the pre-launch of TLC.
 	 */
-	public static final String I_TLC_SNAPSHOT_PREFERENCE = "takeModelSnapshot";
+    public static final String I_TLC_SNAPSHOT_KEEP_COUNT = "numberOfSnapshotsToKeep";
 	
 	// The plug-in ID
 	public static final String PLUGIN_ID = "org.lamport.tla.toolbox.tool.tlc";
@@ -34,7 +40,6 @@ public class TLCActivator extends AbstractUIPlugin {
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
 		plugin = this;
-		plugin.getPreferenceStore().setDefault(I_TLC_SNAPSHOT_PREFERENCE, true);
 	}
 
 	/*

--- a/org.lamport.tla.toolbox.tool.tlc/src/org/lamport/tla/toolbox/tool/tlc/launch/TLCModelLaunchDelegate.java
+++ b/org.lamport.tla.toolbox.tool.tlc/src/org/lamport/tla/toolbox/tool/tlc/launch/TLCModelLaunchDelegate.java
@@ -989,9 +989,8 @@ public class TLCModelLaunchDelegate extends LaunchConfigurationDelegate implemen
              * suffix to identify it as a snapshot. The model for which it is a snapshot is identified by the
              * prefix of the snapshot's model name.
              */
-			final boolean takeSnapshot = TLCActivator.getDefault().getPreferenceStore()
-					.getBoolean(TLCActivator.I_TLC_SNAPSHOT_PREFERENCE);
-			if (!takeSnapshot || model.isSnapshot()) {
+            final int snapshotKeepCount = TLCActivator.getDefault().getPreferenceStore().getInt(TLCActivator.I_TLC_SNAPSHOT_KEEP_COUNT);
+			if (!(snapshotKeepCount > 0) || model.isSnapshot()) {
 				return;
 			}
 			refreshJob = new WorkspaceJob("Taking snapshot of " + model.getName() + "...") {


### PR DESCRIPTION
means none. Snapshot pruning removes the oldest first.

A note should be added to the next release that strongly states that
this new functionality has a default value of 10 and that should the
user have more than the defined preference value of snapshots, the next
time they run the model checker successfully, they will have the older
ones deleted.

Fixes Github issue #104
https://github.com/tlaplus/tlaplus/issues/104

[Feature][Toolbox][Changelog]