### PR TITLE
Include Eclipse UI to configure proxy servers used by Toolbox to contact

### DIFF
--- a/org.lamport.tla.toolbox.doc/html/update/update-preferences.html
+++ b/org.lamport.tla.toolbox.doc/html/update/update-preferences.html
@@ -53,6 +53,34 @@ scheduled time, the search will be done when the Toolbox is next started.
 If you  defer the update, a preference determines if the notification pops up
 again and, if so, when.
 
+<!-- Some content reused from https://help.eclipse.org/oxygen/index.jsp?topic=%2Forg.eclipse.platform.doc.user%2Freference%2Fref-net-preferences.htm -->
+
+<h3>Network Connections</h3>
+If your network environment requires you to setup proxy servers to connect to the internet, you can do so on the
+Network Connections preference page found under <strong>General > Network Connections</strong>.
+
+The <i>Active Provider</i> instructs the Toolbox to use no proxy server (Direct), use the system's proxy server 
+(Native) or the manually defined ones (Manual). 
+
+<ul>
+  <li>Choosing the <i>Direct</i> provider causes all the connections to be opened without the use of a proxy server.</li>
+  <li><i>Native</i> causes settings that were discovered in the operating system to be used (does not work on macOS).</li>
+  <li>Selecting <i>Manual</i> causes settings defined in the <i>Proxy entries</i> table below to be used.</li>
+</ul>
+
+<p>
+When using the Manual provider there are three predefined schemas to set settings for: HTTP, HTTPS and SOCKS.
+Configuration for each schema is displayed in the <i>Proxy entries</i> table. To edit settings for a particular
+schema double-click the entry or select the entry and click Edit... button.
+</p>
+
+<p>
+The <i>Proxy bypass</i> table is only relevant for advanced use cases when different proxies need to be configured
+to access different computers on the internet. Most users can ignore the <i>Proxy bypass</i> table.
+</p>
+
+Please ask your network administrator if the Toolbox fails to access the internet and you do not know what to enter.
+
 <hr>
 <a href="run-update.html">&uarr; Updating the Toolbox</a>
 </hr>

--- a/org.lamport.tla.toolbox.feature.standalone/feature.xml
+++ b/org.lamport.tla.toolbox.feature.standalone/feature.xml
@@ -215,4 +215,51 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.eclipse.ui.net"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.core.net.linux.x86_64"
+         os="linux"
+         arch="x86_64"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.core.net.linux.x86"
+         os="linux"
+         arch="x86"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.core.net.win32.x86_64"
+         os="win32"
+         arch="x86_64"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.core.net.win32.x86"
+         os="win32"
+         arch="x86"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
its p2 update site (currently) located at lamport.org. Proxy servers are
commonly found in sensitive corporate networks.

Include platform-specific bundles to support the "native" provider (use
system's proxy servers).

Fixes Github issue #102 "Proxy servers cannot be configured."
https://github.com/tlaplus/tlaplus/issues/112

[Feature][Toolbox][Changelog]