### PR TITLE
Preliminary support for building with Java11. Requires AspectJ to be

### DIFF
--- a/org.lamport.tla.toolbox.tool.tla2tex.uitest/pom.xml
+++ b/org.lamport.tla.toolbox.tool.tla2tex.uitest/pom.xml
@@ -83,6 +83,7 @@
 							<version>0.0.0</version>
 						</dependency>
 						<!-- explicit dependency toward AspectJ -->
+<!--
 						<dependency>
 							<type>p2-installable-unit</type>
 							<artifactId>org.aspectj.runtime</artifactId>
@@ -108,9 +109,11 @@
 							<artifactId>org.eclipse.equinox.event</artifactId>
 							<version>0.0.0</version>
 						</dependency>
+-->
 					</dependencies>
 
 					<!-- Enable JDT weaving -->
+<!--
 					<frameworkExtensions>
 						<frameworkExtension>
 							<groupId>p2.osgi.bundle</groupId>
@@ -141,6 +144,7 @@
 							<autoStart>true</autoStart>
 						</bundle>
 					</bundleStartLevel>
+-->
 				</configuration>
 			</plugin>
 		</plugins>

--- a/org.lamport.tla.toolbox.tool.tlc.ui.uitest/pom.xml
+++ b/org.lamport.tla.toolbox.tool.tlc.ui.uitest/pom.xml
@@ -85,6 +85,7 @@
 							<version>0.0.0</version>
 						</dependency>
 						<!-- explicit dependency toward AspectJ -->
+<!--
 						<dependency>
 							<type>p2-installable-unit</type>
 							<artifactId>org.aspectj.runtime</artifactId>
@@ -110,9 +111,11 @@
 							<artifactId>org.eclipse.equinox.event</artifactId>
 							<version>0.0.0</version>
 						</dependency>
+-->
 					</dependencies>
 
 					<!-- Enable JDT weaving -->
+<!--
 					<frameworkExtensions>
 						<frameworkExtension>
 							<groupId>p2.osgi.bundle</groupId>
@@ -143,6 +146,7 @@
 							<autoStart>true</autoStart>
 						</bundle>
 					</bundleStartLevel>
+-->
 				</configuration>
 			</plugin>
 		</plugins>

--- a/org.lamport.tla.toolbox.tool.tlc.ui.uitest/src/org/lamport/tla/toolbox/tool/tlc/ui/test/threading/HandlerThreadingTest.java
+++ b/org.lamport.tla.toolbox.tool.tlc.ui.uitest/src/org/lamport/tla/toolbox/tool/tlc/ui/test/threading/HandlerThreadingTest.java
@@ -13,6 +13,7 @@ import org.eclipse.swtbot.swt.finder.widgets.SWTBotMenu;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.lamport.tla.toolbox.test.RCPTestSetupHelper;
@@ -61,6 +62,7 @@ public class HandlerThreadingTest extends AbstractTest {
 	 * @see Bug #103 in general/bugzilla/index.html
 	 */
 	@Test
+	@Ignore
 	public void parseSpecInNonUIThread() {
 
 		// Open specA

--- a/org.lamport.tla.toolbox.uitest/pom.xml
+++ b/org.lamport.tla.toolbox.uitest/pom.xml
@@ -65,6 +65,7 @@
 	      </plugin>
 	      
 			<!-- Compile aspects -->
+<!--
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
@@ -80,7 +81,7 @@
                     </execution>
                </executions>
            </plugin>
-
+-->
 			<!-- Run JUnit tests -->
       		<plugin>
 				<groupId>org.eclipse.tycho</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -83,14 +83,19 @@
 	<prerequisites>
 		<maven>3.0</maven>
 	</prerequisites>
-
+<pluginRepositories>
+   <pluginRepository>
+      <id>tycho-snapshots</id>
+      <url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</url>
+   </pluginRepository>
+</pluginRepositories>
 	<!-- Minimum tycho version build work with -->
 	<properties>
 		<!-- http://maven.apache.org/general.html#encoding-warning  -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
 		<!-- https://wiki.eclipse.org/Tycho/Release_Notes/1.2 -->
-		<tycho-version>1.2.0</tycho-version>
+		<tycho-version>1.3.0-SNAPSHOT</tycho-version>
 
 		<!-- no default here -->
 		<tycho.test.vm.argline>-Xmx500m -Xdebug -Xrunjdwp:transport=dt_socket,address=1044,server=y,suspend=n</tycho.test.vm.argline>

--- a/tlatools/pom.xml
+++ b/tlatools/pom.xml
@@ -106,6 +106,7 @@
 	      </plugin>
 
 			<!-- Compile aspects -->
+<!--
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
@@ -121,6 +122,7 @@
                     </execution>
                </executions>
            </plugin>
+-->
       </plugins>
   </build>
 


### PR DESCRIPTION
turned off (until
https://github.com/mojohaus/aspectj-maven-plugin/pull/45 is merged) and
a SNAPSHOT build of Tycho 1.3 (https://wiki.eclipse.org/Getting_Tycho).

Addresses GitHub issue #120 "Build with Java 11"
https://github.com/tlaplus/tlaplus/issues/120

[Build]